### PR TITLE
Constrain boto3 and aiobotocore in package_constraints to prevent botocore version conflicts

### DIFF
--- a/homeassistant/components/amazon_polly/manifest.json
+++ b/homeassistant/components/amazon_polly/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/amazon_polly",
   "iot_class": "cloud_push",
   "loggers": ["boto3", "botocore", "s3transfer"],
-  "requirements": ["boto3==1.34.131"]
+  "requirements": ["boto3==1.42.97"]
 }

--- a/homeassistant/components/aws/manifest.json
+++ b/homeassistant/components/aws/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/aws",
   "iot_class": "cloud_push",
   "loggers": ["aiobotocore", "botocore"],
-  "requirements": ["aiobotocore==2.13.1", "botocore==1.34.131"]
+  "requirements": ["aiobotocore==3.7.0"]
 }

--- a/homeassistant/components/route53/manifest.json
+++ b/homeassistant/components/route53/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/route53",
   "iot_class": "cloud_push",
   "loggers": ["boto3", "botocore", "s3transfer"],
-  "requirements": ["boto3==1.34.131"]
+  "requirements": ["boto3==1.42.97"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -135,6 +135,12 @@ iso4217!=1.10.20220401
 # cryptography 42.0.0 is installed with botocore
 pyOpenSSL>=24.0.0
 
+# Constrain boto3 and aiobotocore to avoid conflicts where custom integrations
+# install incompatible botocore versions, breaking aiobotocore-based integrations.
+# https://github.com/home-assistant/core/pull/170783
+boto3>=1.42.97
+aiobotocore>=3.7.0
+
 # protobuf must be in package constraints for the wheel
 # builder to build binary wheels
 protobuf==4.25.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -207,7 +207,7 @@ aioazuredevops==2.2.1
 aiobafi6==0.9.0
 
 # homeassistant.components.aws
-aiobotocore==2.13.1
+aiobotocore==3.7.0
 
 # homeassistant.components.comelit
 aiocomelit==0.9.0
@@ -613,10 +613,7 @@ boschshcpy==0.2.91
 
 # homeassistant.components.amazon_polly
 # homeassistant.components.route53
-boto3==1.34.131
-
-# homeassistant.components.aws
-botocore==1.34.131
+boto3==1.42.97
 
 # homeassistant.components.bring
 bring-api==0.8.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -195,7 +195,7 @@ aioazuredevops==2.2.1
 aiobafi6==0.9.0
 
 # homeassistant.components.aws
-aiobotocore==2.13.1
+aiobotocore==3.7.0
 
 # homeassistant.components.comelit
 aiocomelit==0.9.0
@@ -534,9 +534,6 @@ bond-async==0.2.1
 
 # homeassistant.components.bosch_shc
 boschshcpy==0.2.91
-
-# homeassistant.components.aws
-botocore==1.34.131
 
 # homeassistant.components.bring
 bring-api==0.8.1


### PR DESCRIPTION
## Problem

Custom integrations inadvertently break `aiobotocore`-based integrations (AWS, AWS S3, Cloudflare R2, IDrive E2) by installing an incompatible version of `botocore`, causing:

```
TypeError: ClientArgsCreator.compute_endpoint_resolver_builtin_defaults()
  missing 1 required positional argument: 's3_disable_express_session_auth'
```

## Solution

Per maintainer feedback on #170783, instead of only bumping versions in individual integration manifests, add `boto3` and `aiobotocore` to `homeassistant/package_constraints.txt`. This enforces a globally compatible minimum version and prevents custom integrations from pulling in conflicting older releases.

## Changes

- **`homeassistant/package_constraints.txt`**: Add `boto3>=1.42.97` and `aiobotocore>=3.7.0` constraints
- **`homeassistant/components/aws/manifest.json`**: Bump `aiobotocore` 2.13.1 → 3.7.0, remove now-redundant explicit `botocore` pin (aiobotocore bundles its own botocore)
- **`homeassistant/components/amazon_polly/manifest.json`**: Bump `boto3` 1.34.131 → 1.42.97
- **`homeassistant/components/route53/manifest.json`**: Bump `boto3` 1.34.131 → 1.42.97
- **`requirements_all.txt`** / **`requirements_test_all.txt`**: Updated accordingly

## Related

- Closes #170783 (previous approach was to bump only in individual manifests)
- Fixes issues reported in: home-assistant/core#170783


---
_Generated by [Claude Code](https://claude.ai/code/session_01HLMdz17hmyVmeE6KJMf24n)_